### PR TITLE
User-facing string tweaks for Campaign Members

### DIFF
--- a/src/steps/campaign-member-field-equals.ts
+++ b/src/steps/campaign-member-field-equals.ts
@@ -5,18 +5,18 @@ import { Step, RunStepResponse, FieldDefinition, StepDefinition } from '../proto
 
 export class CampaignMemberFieldEquals extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check a CampaignMember Field Value';
+  protected stepName: string = 'Check a Salesforce Campaign Member Field';
   /* tslint:disable-next-line:max-line-length */
-  protected stepExpression: string = 'the salesforce campaignmember (?<email>.+) should be a member of campaign (?<campaignId>.+) with (?<field>.+) set to (?<expectedValue>.+)';
+  protected stepExpression: string = 'the salesforce lead (?<email>.+) should be a member of campaign (?<campaignId>.+) with (?<field>.+) set to (?<expectedValue>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'email',
     type: FieldDefinition.Type.EMAIL,
-    description: "CampaignMember's email address",
+    description: "Lead's email address",
   }, {
     field: 'campaignId',
     type: FieldDefinition.Type.STRING,
-    description: 'CampaignId',
+    description: "Campaign ID",
   }, {
     field: 'field',
     type: FieldDefinition.Type.STRING,
@@ -39,24 +39,24 @@ export class CampaignMemberFieldEquals extends BaseStep implements StepInterface
       // tslint:disable-next-line:max-line-length
       campaignMember = await this.client.findCampaignMemberByEmailAndCampaignId(email, campaignId, [field]);
     } catch (e) {
-      return this.error('There was a problem checking the CampaignMember: %s', [e.toString()]);
+      return this.error('There was a problem checking the Campaign Member: %s', [e.toString()]);
     }
 
     if (!campaignMember) {
-      // If no results were found, return an error.
+      // If no results were found, return a failure.
       // tslint:disable-next-line:max-line-length
-      return this.error('No CampaignMember found with email %s and campaignId %s', [email, campaignId]);
+      return this.fail('No Campaign Membership found between %s and campaign %s', [email, campaignId]);
     } else if (!campaignMember.hasOwnProperty(field)) {
       // If the given field does not exist on the user, return an error.
       // tslint:disable-next-line:max-line-length
-      return this.error('The %s field does not exist on CampaignMember with email %s', [field, email]);
+      return this.error('The %s field does not exist on Campaign Member with email %s and campaign id %s', [field, email, campaignId]);
     // tslint:disable-next-line:triple-equals
     } else if (campaignMember[field] == expectedValue) {
       // If the value of the field matches expectations, pass.
-      return this.pass('The %s field was set to %s, as expected', [field, campaignMember[field]]);
+      return this.pass('The %s Campaign Member field was set to %s, as expected', [field, campaignMember[field]]);
     } else {
       // If the value of the field does not match expectations, fail.
-      return this.fail('Expected %s field to be %s, but it was actually %s', [
+      return this.fail('Expected Campaign Member %s field to be %s, but it was actually %s', [
         field,
         expectedValue,
         campaignMember[field],

--- a/src/steps/campaign-member-field-equals.ts
+++ b/src/steps/campaign-member-field-equals.ts
@@ -16,7 +16,7 @@ export class CampaignMemberFieldEquals extends BaseStep implements StepInterface
   }, {
     field: 'campaignId',
     type: FieldDefinition.Type.STRING,
-    description: "Campaign ID",
+    description: 'Campaign ID',
   }, {
     field: 'field',
     type: FieldDefinition.Type.STRING,
@@ -53,6 +53,7 @@ export class CampaignMemberFieldEquals extends BaseStep implements StepInterface
     // tslint:disable-next-line:triple-equals
     } else if (campaignMember[field] == expectedValue) {
       // If the value of the field matches expectations, pass.
+      // tslint:disable-next-line:max-line-length
       return this.pass('The %s Campaign Member field was set to %s, as expected', [field, campaignMember[field]]);
     } else {
       // If the value of the field does not match expectations, fail.

--- a/src/steps/campaign-member-id-equals.ts
+++ b/src/steps/campaign-member-id-equals.ts
@@ -16,7 +16,7 @@ export class CampaignMemberCampaignIdEquals extends BaseStep implements StepInte
   }, {
     field: 'campaignId',
     type: FieldDefinition.Type.STRING,
-    description: "Campaign ID",
+    description: 'Campaign ID',
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {

--- a/src/steps/campaign-member-id-equals.ts
+++ b/src/steps/campaign-member-id-equals.ts
@@ -5,18 +5,18 @@ import { Step, RunStepResponse, FieldDefinition, StepDefinition } from '../proto
 
 export class CampaignMemberCampaignIdEquals extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check CampaignMember Campaign Membership';
+  protected stepName: string = 'Check Salesforce Campaign Membership';
   /* tslint:disable-next-line:max-line-length */
-  protected stepExpression: string = 'the salesforce campaignmember (?<email>.+) should be a member of campaign (?<campaignId>.+)';
+  protected stepExpression: string = 'the salesforce lead (?<email>.+) should be a member of campaign (?<campaignId>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'email',
     type: FieldDefinition.Type.EMAIL,
-    description: "CampaignMember's email address",
+    description: "Lead's email address",
   }, {
     field: 'campaignId',
     type: FieldDefinition.Type.STRING,
-    description: "CampaignMember's CampaignId",
+    description: "Campaign ID",
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {
@@ -30,18 +30,18 @@ export class CampaignMemberCampaignIdEquals extends BaseStep implements StepInte
       // tslint:disable-next-line:max-line-length
       campaignMember = await this.client.findCampaignMemberByEmailAndCampaignId(email, campaignId, [field]);
     } catch (e) {
-      return this.error('There was a problem checking the CampaignMember: %s', [e.toString()]);
+      return this.error('There was a problem checking the Campaign Member: %s', [e.toString()]);
     }
 
     if (!campaignMember) {
-      // If no results were found, return an error.
+      // If no results were found, return a failure.
       // tslint:disable-next-line:max-line-length
-      return this.fail('No CampaignMember found with email %s and campaignId %s', [email, campaignId]);
+      return this.fail('No Campaign Membership found between %s and campaign %s', [email, campaignId]);
     // tslint:disable-next-line:triple-equals
     } else {
       // If the value of the field matches expectations, pass.
       // tslint:disable-next-line:max-line-length
-      return this.pass('CampaignMember belongs to Campaign with id %s, as expected', [field, campaignId]);
+      return this.pass('Lead belongs to Campaign with id %s, as expected', [campaignId]);
     }
   }
 

--- a/test/steps/campaign-member-field-equals.ts
+++ b/test/steps/campaign-member-field-equals.ts
@@ -24,8 +24,8 @@ describe('CampaignMemberFieldEqualsStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CampaignMemberFieldEquals');
-    expect(stepDef.getName()).to.equal('Check a CampaignMember Field Value');
-    expect(stepDef.getExpression()).to.equal('the salesforce campaignmember (?<email>.+) should be a member of campaign (?<campaignId>.+) with (?<field>.+) set to (?<expectedValue>.+)');
+    expect(stepDef.getName()).to.equal('Check a Salesforce Campaign Member Field');
+    expect(stepDef.getExpression()).to.equal('the salesforce lead (?<email>.+) should be a member of campaign (?<campaignId>.+) with (?<field>.+) set to (?<expectedValue>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });
 
@@ -75,9 +75,9 @@ describe('CampaignMemberFieldEqualsStep', () => {
     expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
   });
 
-  it('should respond with error if API client does not find Lead', async () => {
+  it('should respond with fail if API client does not find campaign member', async () => {
     // Stub a response that matches expectations.
-    const expectedResponseMessage: string = 'No CampaignMember found with email %s and campaignId %s';
+    const expectedResponseMessage: string = 'No Campaign Membership found between %s and campaign %s';
     clientWrapperStub.findCampaignMemberByEmailAndCampaignId.resolves(null);
 
     // Set step data corresponding to expectations
@@ -91,12 +91,12 @@ describe('CampaignMemberFieldEqualsStep', () => {
 
     const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
     expect(response.getMessageFormat()).to.equal(expectedResponseMessage);
-    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.ERROR);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.FAILED);
   });
 
-  it('should respond with error if API client gets the lead without expected field', async () => {
+  it('should respond with error if API client gets the campaign member without expected field', async () => {
     // Stub a response that matches expectations.
-    const expectedResponseMessage: string = 'The %s field does not exist on CampaignMember with email %s';
+    const expectedResponseMessage: string = 'The %s field does not exist on Campaign Member with email %s and campaign id %s';
     const expectedUser: any = { CampaignId: 'someId', someOtherField: 'someValue' };
     clientWrapperStub.findCampaignMemberByEmailAndCampaignId.resolves(expectedUser);
 
@@ -116,7 +116,7 @@ describe('CampaignMemberFieldEqualsStep', () => {
 
   it('should respond with fail if API client resolved unexpected data', async () => {
     // Stub a response that matches expectations.
-    const expectedResponseMessage: string = 'Expected %s field to be %s, but it was actually %s';
+    const expectedResponseMessage: string = 'Expected Campaign Member %s field to be %s, but it was actually %s';
     const expectedUser: any = { CampaignId: 'someId', someField: 'someOtherValue' };
     clientWrapperStub.findCampaignMemberByEmailAndCampaignId.resolves(expectedUser);
 
@@ -137,7 +137,7 @@ describe('CampaignMemberFieldEqualsStep', () => {
 
   it('should respond with error if API client throws an exception', async () => {
     // Stub a response that matches expectations.
-    const expectedResponseMessage: string = 'There was a problem checking the CampaignMember: %s';
+    const expectedResponseMessage: string = 'There was a problem checking the Campaign Member: %s';
     const expectedError: Error = new Error('Any Error');
     clientWrapperStub.findCampaignMemberByEmailAndCampaignId.rejects(expectedError);
 

--- a/test/steps/campaign-member-id-equals.ts
+++ b/test/steps/campaign-member-id-equals.ts
@@ -24,8 +24,8 @@ describe('CampaignMemberCampaignIdEqualsStep', () => {
   it('should return expected step metadata', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CampaignMemberCampaignIdEquals');
-    expect(stepDef.getName()).to.equal('Check CampaignMember Campaign Membership');
-    expect(stepDef.getExpression()).to.equal('the salesforce campaignmember (?<email>.+) should be a member of campaign (?<campaignId>.+)');
+    expect(stepDef.getName()).to.equal('Check Salesforce Campaign Membership');
+    expect(stepDef.getExpression()).to.equal('the salesforce lead (?<email>.+) should be a member of campaign (?<campaignId>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });
 
@@ -65,7 +65,7 @@ describe('CampaignMemberCampaignIdEqualsStep', () => {
 
   it('should respond with fail if API client does not find Campaign Member', async () => {
     // Stub a response that matches expectations.
-    const expectedResponseMessage: string = 'No CampaignMember found with email %s and campaignId %s';
+    const expectedResponseMessage: string = 'No Campaign Membership found between %s and campaign %s';
     clientWrapperStub.findCampaignMemberByEmailAndCampaignId.resolves(null);
 
     // Set step data corresponding to expectations
@@ -82,7 +82,7 @@ describe('CampaignMemberCampaignIdEqualsStep', () => {
 
   it('should respond with error if API client throws an exception', async () => {
     // Stub a response that matches expectations.
-    const expectedResponseMessage: string = 'There was a problem checking the CampaignMember: %s';
+    const expectedResponseMessage: string = 'There was a problem checking the Campaign Member: %s';
     const expectedError: Error = new Error('Any Error');
     clientWrapperStub.findCampaignMemberByEmailAndCampaignId.rejects(expectedError);
 


### PR DESCRIPTION
- Adds `Salesforce` keyword to step names
- Standardizes on `Campaign Member` as representation for object (as is displayed in SFDC UI)
- Minor readability improvements to error messages.