### PR TITLE
Changed Campaign Member Field Validation Expression

### DIFF
--- a/src/steps/campaign-member-field-equals.ts
+++ b/src/steps/campaign-member-field-equals.ts
@@ -7,7 +7,7 @@ export class CampaignMemberFieldEquals extends BaseStep implements StepInterface
 
   protected stepName: string = 'Check a field on a Salesforce Campaign Member';
   /* tslint:disable-next-line:max-line-length */
-  protected stepExpression: string = 'the salesforce lead (?<email>.+) should be a member of campaign (?<campaignId>.+) with (?<field>.+) set to (?<expectedValue>.+)';
+  protected stepExpression: string = 'the salesforce lead (?<email>.+) should have campaign member (?<field>.+) set to (?<expectedValue>.+) on campaign (?<campaignId>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'email',

--- a/test/steps/campaign-member-field-equals.ts
+++ b/test/steps/campaign-member-field-equals.ts
@@ -25,7 +25,7 @@ describe('CampaignMemberFieldEqualsStep', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CampaignMemberFieldEquals');
     expect(stepDef.getName()).to.equal('Check a field on a Salesforce Campaign Member');
-    expect(stepDef.getExpression()).to.equal('the salesforce lead (?<email>.+) should be a member of campaign (?<campaignId>.+) with (?<field>.+) set to (?<expectedValue>.+)');
+    expect(stepDef.getExpression()).to.equal('the salesforce lead (?<email>.+) should have campaign member (?<field>.+) set to (?<expectedValue>.+) on campaign (?<campaignId>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });
 


### PR DESCRIPTION
changed expression to resolve a bug on campaign member field validation step getting the rest of the sentence after campaign Id being considered as campaign Id also.