### PR TITLE
Fix issue preventing Cogs from being installed via docker image

### DIFF
--- a/src/core/cog.ts
+++ b/src/core/cog.ts
@@ -30,7 +30,9 @@ export class Cog implements ICogServiceServer {
       }
     });
 
-    return steps;
+    // Note: this filters out files that do not match the above (e.g. READMEs
+    // or .js.map files in built folder, etc).
+    return steps.filter(s => s !== undefined);
   }
 
   getManifest(


### PR DESCRIPTION
Underlying issue is that `tsc` adds `.js.map` files in the build folder, which were picked up by recent changes to account for foldered steps (#26).  Because those files did not meet any of the conditional criteria in the private `getSteps()` method (ends in `.ts` or `.js`, or is a directory), they would result in `undefined`, which did not jive well with the subsequent `getDefinition()` call that was made on it in the `getManifest()` method, yielding the following:

```
Server started, listening: 0.0.0.0:28866
/app/build/core/cog.js:69
            return step.getDefinition();
                        ^

TypeError: Cannot read property 'getDefinition' of undefined
    at /app/build/core/cog.js:69:25
    at Array.map (<anonymous>)
    at Cog.getManifest (/app/build/core/cog.js:68:42)
    at /app/node_modules/grpc/src/server.js:590:13
```

In the future we can/should prevent this by attempting to install the built docker image using crank in a build.