### PR TITLE
Fixed steps from removing whitespace to operators when determining pa…

### DIFF
--- a/src/steps/account/account-field-equals.ts
+++ b/src/steps/account/account-field-equals.ts
@@ -62,10 +62,10 @@ export class AccountFieldEquals extends BaseStep implements StepInterface {
         return this.error('The %s field does not exist on Account %s', [field, identifier]);
       } else if (this.compare(operator, account[0][field], expectedValue)) {
         // If the value of the field matches expectations, pass.
-        return this.pass(this.operatorSuccessMessages[operator.replace(/\s/g, '').toLowerCase()], [field, expectedValue]);
+        return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue]);
       } else {
         // If the value of the field does not match expectations, fail.
-        return this.fail(this.operatorFailMessages[operator.replace(/\s/g, '').toLowerCase()], [
+        return this.fail(this.operatorFailMessages[operator], [
           field,
           expectedValue,
           account[0][field],

--- a/src/steps/contact/contact-field-equals.ts
+++ b/src/steps/contact/contact-field-equals.ts
@@ -51,9 +51,9 @@ export class ContactFieldEqualsStep extends BaseStep implements StepInterface {
         return this.error('The %s field does not exist on Contact %s', [field, email]);
         /* tslint:disable-next-line:triple-equals */
       } else if (this.compare(operator, contact[field], expectedValue)) {
-        return this.pass(this.operatorSuccessMessages[operator.replace(/\s/g, '').toLowerCase()], [field, expectedValue]);
+        return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue]);
       } else {
-        return this.fail(this.operatorFailMessages[operator.replace(/\s/g, '').toLowerCase()], [
+        return this.fail(this.operatorFailMessages[operator], [
           field,
           expectedValue,
           contact[field],

--- a/src/steps/opportunity/opportunity-field-equals.ts
+++ b/src/steps/opportunity/opportunity-field-equals.ts
@@ -63,10 +63,10 @@ export class OpportunityFieldEquals extends BaseStep implements StepInterface {
         return this.error('The %s field does not exist on Opportunity %s', [field, identifier]);
       } else if (this.compare(operator, opportunity[0][field], expectedValue)) {
         // If the value of the field matches expectations, pass.
-        return this.pass(this.operatorSuccessMessages[operator.replace(/\s/g, '').toLowerCase()], [field, expectedValue]);
+        return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue]);
       } else {
         // If the value of the field does not match expectations, fail.
-        return this.fail(this.operatorFailMessages[operator.replace(/\s/g, '').toLowerCase()], [
+        return this.fail(this.operatorFailMessages[operator], [
           field,
           expectedValue,
           opportunity[0][field],


### PR DESCRIPTION
The `util` had a change in determining proper `pass/fail` messages as seen on:

https://github.com/run-crank/typescript-cog-utilities/blob/master/src/utils/compare.ts#L4

There are steps affected that still has the `.replace(/\s/g, '').toLowerCase()` code which removes all space and then therefore cannot be mapped to the updated pass fail messages in the `util` (which now contains space)