### PR TITLE
Fixed the error message for campaign member errors

### DIFF
--- a/src/steps/campaign-member/campaign-member-field-equals.ts
+++ b/src/steps/campaign-member/campaign-member-field-equals.ts
@@ -52,7 +52,7 @@ export class CampaignMemberFieldEquals extends BaseStep implements StepInterface
       'greater than': 'be greater than',
     };
 
-    operator = normalizedOperators[operator];
+    operator = normalizedOperators[operator] || stepData.operator;
 
     try {
       campaignMember = await this.client.findCampaignMemberByEmailAndCampaignId(email, campaignId, [field]);


### PR DESCRIPTION
This should fix: https://github.com/run-crank/typescript-cog-utilities/issues/9

The `Campaign Member` object uses the same operator but represented as different strings. When mapping is attempted and did not match. The operator is set to `empty string`.

Fixed by using the `stepData.operator` in the error message.