### PR TITLE
Remove stray whitespace from salesforce object record ID

### DIFF
--- a/src/steps/object-create.ts
+++ b/src/steps/object-create.ts
@@ -16,7 +16,7 @@ export class CreateObject extends BaseStep implements StepInterface {
     description: 'where keys represent object field names as represented in the SFDC API',
   }];
   protected expectedRecords: ExpectedRecord[] = [{
-    id: 'salesforceObject ',
+    id: 'salesforceObject',
     type: RecordDefinition.Type.KEYVALUE,
     fields: [{
       field: 'Id',
@@ -30,7 +30,7 @@ export class CreateObject extends BaseStep implements StepInterface {
     const stepData: any = step.getData().toJavaScript();
     const objName: any = stepData.objName;
     const salesforceObject: any = stepData.salesforceObject;
-    console.log(stepData);
+
     try {
       const result = await this.client.createObject(objName, salesforceObject);
       const record = this.keyValue('salesforceObject', 'Created Object', { Id: result.id });

--- a/src/steps/object-delete.ts
+++ b/src/steps/object-delete.ts
@@ -16,7 +16,7 @@ export class DeleteObject extends BaseStep implements StepInterface {
     description: 'Object ID',
   }];
   protected expectedRecords: ExpectedRecord[] = [{
-    id: 'salesforceObject ',
+    id: 'salesforceObject',
     type: RecordDefinition.Type.KEYVALUE,
     fields: [{
       field: 'Id',

--- a/src/steps/object-update.ts
+++ b/src/steps/object-update.ts
@@ -16,7 +16,7 @@ export class UpdateObject extends BaseStep implements StepInterface {
     description: 'where keys represent object field names as represented in the SFDC API',
   }];
   protected expectedRecords: ExpectedRecord[] = [{
-    id: 'salesforceObject ',
+    id: 'salesforceObject',
     type: RecordDefinition.Type.KEYVALUE,
     fields: [{
       field: 'Id',


### PR DESCRIPTION
Also removes a stray `console.log`