### PR TITLE
Re-order regex operator options on CM check step

### DIFF
--- a/src/steps/campaign-member/campaign-member-field-equals.ts
+++ b/src/steps/campaign-member/campaign-member-field-equals.ts
@@ -10,7 +10,7 @@ export class CampaignMemberFieldEquals extends BaseStep implements StepInterface
 
   protected stepName: string = 'Check a field on a Salesforce Campaign Member';
   /* tslint:disable-next-line:max-line-length */
-  protected stepExpression: string = 'the salesforce lead (?<email>.+) should have campaign member (?<field>[a-z0-9_]+) (?<operator>set|not set|set to|not set to|containing|not containing|less than|greater than) ?(?<expectedValue>.+)? on campaign (?<campaignId>.+)';
+  protected stepExpression: string = 'the salesforce lead (?<email>.+) should have campaign member (?<field>[a-z0-9_]+) (?<operator>set to|set|not set to|not set|containing|not containing|less than|greater than) ?(?<expectedValue>.+)? on campaign (?<campaignId>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
   protected expectedFields: Field[] = [{
     field: 'email',

--- a/test/steps/campaign-member/campaign-member-field-equals.ts
+++ b/test/steps/campaign-member/campaign-member-field-equals.ts
@@ -26,7 +26,7 @@ describe('CampaignMemberFieldEqualsStep', () => {
     const stepDef: StepDefinition = stepUnderTest.getDefinition();
     expect(stepDef.getStepId()).to.equal('CampaignMemberFieldEquals');
     expect(stepDef.getName()).to.equal('Check a field on a Salesforce Campaign Member');
-    expect(stepDef.getExpression()).to.equal('the salesforce lead (?<email>.+) should have campaign member (?<field>[a-z0-9_]+) (?<operator>set|not set|set to|not set to|containing|not containing|less than|greater than) ?(?<expectedValue>.+)? on campaign (?<campaignId>.+)');
+    expect(stepDef.getExpression()).to.equal('the salesforce lead (?<email>.+) should have campaign member (?<field>[a-z0-9_]+) (?<operator>set to|set|not set to|not set|containing|not containing|less than|greater than) ?(?<expectedValue>.+)? on campaign (?<campaignId>.+)');
     expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
   });
 


### PR DESCRIPTION
...to resolve BC regression for new `set` and `not set`operators.