### PR TITLE
Fix on empty balue on result messages on all objects

### DIFF
--- a/src/steps/account/account-field-equals.ts
+++ b/src/steps/account/account-field-equals.ts
@@ -97,7 +97,7 @@ export class AccountFieldEquals extends BaseStep implements StepInterface {
         return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue || ''], [record]);
       } else {
         // If the value of the field does not match expectations, fail.
-        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || '', account[0][field]], [record]);
+        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || account[0][field], account[0][field]], [record]);
       }
     } catch (e) {
       if (e instanceof util.UnknownOperatorError) {

--- a/src/steps/campaign-member/campaign-member-field-equals.ts
+++ b/src/steps/campaign-member/campaign-member-field-equals.ts
@@ -122,7 +122,7 @@ export class CampaignMemberFieldEquals extends BaseStep implements StepInterface
         return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue || ''], [record]);
       } else {
         // If the value of the field does not match expectations, fail.
-        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || '', campaignMember[field]], [record]);
+        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || campaignMember[field], campaignMember[field]], [record]);
       }
     } catch (e) {
       if (e instanceof util.UnknownOperatorError) {

--- a/src/steps/contact/contact-field-equals.ts
+++ b/src/steps/contact/contact-field-equals.ts
@@ -80,7 +80,7 @@ export class ContactFieldEqualsStep extends BaseStep implements StepInterface {
       } else if (this.compare(operator, contact[field], expectedValue)) {
         return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue || ''], [record]);
       } else {
-        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || '', contact[field]], [record]);
+        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || contact[field], contact[field]], [record]);
       }
     } catch (e) {
       if (e instanceof util.UnknownOperatorError) {

--- a/src/steps/lead/lead-field-equals.ts
+++ b/src/steps/lead/lead-field-equals.ts
@@ -85,7 +85,7 @@ export class LeadFieldEquals extends BaseStep implements StepInterface {
         return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue || ''], [record]);
       } else {
         // If the value of the field does not match expectations, fail.
-        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || '', lead[field]], [record]);
+        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || lead[field], lead[field]], [record]);
       }
     } catch (e) {
       if (e instanceof util.UnknownOperatorError) {

--- a/src/steps/object-field-equals.ts
+++ b/src/steps/object-field-equals.ts
@@ -89,7 +89,7 @@ export class ObjectFieldEquals extends BaseStep implements StepInterface {
         return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue || ''], [record]);
       } else {
         // If the value of the field does not match expectations, fail.
-        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || '', object[field]], [record]);
+        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || object[field], object[field]], [record]);
       }
     } catch (e) {
       if (e instanceof util.UnknownOperatorError) {

--- a/src/steps/opportunity/opportunity-field-equals.ts
+++ b/src/steps/opportunity/opportunity-field-equals.ts
@@ -97,7 +97,7 @@ export class OpportunityFieldEquals extends BaseStep implements StepInterface {
         // If the value of the field does not match expectations, fail.
         return this.fail(
           this.operatorFailMessages[operator],
-          [field, expectedValue || '', opportunity[0][field]],
+          [field, expectedValue || opportunity[0][field], opportunity[0][field]],
           [record],
         );
       }


### PR DESCRIPTION
Changed `''` to result field value instead to fix `(empty value)` displaying when using `set operators`