### PR TITLE
Util Update and Display Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,9 +165,9 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.3.0.tgz",
-      "integrity": "sha512-ZG/gSv4OLzC99du5D1gXEF6j3lGp/MrwPrk9cfRY+RGJJcLzT6V34PKLNgQI4z7QG3VnFxUyr6RRXv6VDqjtwg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.3.2.tgz",
+      "integrity": "sha512-OiKEQMJEdGh+NXwjLCynAAXQ1Ru7UyYxIoRJiBAG8MxWCElaIJPk6YJ7xlpTyPMaKB3Ulfe4IQhla5KLXWZkeQ==",
       "requires": {
         "csv-string": "^4.0.1",
         "moment": "^2.24.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.3.0",
+    "@run-crank/utilities": "^0.3.2",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.3",
     "jsforce": "^1.9.3",

--- a/src/steps/lead/lead-field-equals.ts
+++ b/src/steps/lead/lead-field-equals.ts
@@ -57,6 +57,7 @@ export class LeadFieldEquals extends BaseStep implements StepInterface {
     const field: string = stepData.field;
     const operator: string = stepData.operator || 'be';
     const expectedValue: string = stepData.expectedValue;
+    const isSetOperator = ['be set', 'not be set'].includes(operator);
     let lead: Record<string, any>;
 
     if (isNullOrUndefined(expectedValue) && !(operator == 'be set' || operator == 'not be set')) {
@@ -85,7 +86,12 @@ export class LeadFieldEquals extends BaseStep implements StepInterface {
         return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue || ''], [record]);
       } else {
         // If the value of the field does not match expectations, fail.
-        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || lead[field], lead[field]], [record]);
+        const printValue = [null, undefined].includes(lead[field]) ? '' : lead[field];
+        return this.fail(
+          this.operatorFailMessages[operator],
+          [field, expectedValue || printValue, isSetOperator ? '' : printValue],
+          [record],
+        );
       }
     } catch (e) {
       if (e instanceof util.UnknownOperatorError) {

--- a/src/steps/object-field-equals.ts
+++ b/src/steps/object-field-equals.ts
@@ -61,6 +61,7 @@ export class ObjectFieldEquals extends BaseStep implements StepInterface {
     const id: string = stepData.id;
     const operator: string = stepData.operator || 'be';
     const expectedValue: string = stepData.expectedValue;
+    const isSetOperator = ['be set', 'not be set'].includes(operator);
     let object: Record<string, any>;
 
     if (isNullOrUndefined(expectedValue) && !(operator == 'be set' || operator == 'not be set')) {
@@ -89,7 +90,12 @@ export class ObjectFieldEquals extends BaseStep implements StepInterface {
         return this.pass(this.operatorSuccessMessages[operator], [field, expectedValue || ''], [record]);
       } else {
         // If the value of the field does not match expectations, fail.
-        return this.fail(this.operatorFailMessages[operator], [field, expectedValue || object[field], object[field]], [record]);
+        const printValue = [null, undefined].includes(object[field]) ? '' : object[field];
+        return this.fail(
+          this.operatorFailMessages[operator],
+          [field, expectedValue || printValue, isSetOperator ? '' : printValue],
+          [record],
+        );
       }
     } catch (e) {
       if (e instanceof util.UnknownOperatorError) {


### PR DESCRIPTION
# Fixed
1. An issue wherein sometimes `(empty value)` is displayed for failing Set Operator displays/messages
2. An issue wherein the `but it was set to <value>` message displays the `<value>` twice.