### PR TITLE
clearCache will also clear the Saleloft cache

### DIFF
--- a/src/client/caching-client-wrapper.ts
+++ b/src/client/caching-client-wrapper.ts
@@ -181,12 +181,12 @@ class CachingClientWrapper {
   }
 
   public async updateObject(objName: string, object: Record<string, any>) {
-    this.clearCache();
+    await this.clearCache();
     return await this.client.updateObject(objName, object);
   }
 
   public async deleteObjectById(objName: string, id: string) {
-    this.clearCache();
+    await this.clearCache();
     return await this.client.deleteObjectById(objName, id);
   }
 
@@ -264,11 +264,15 @@ class CachingClientWrapper {
   public async clearCache() {
     try {
       // clears all the cachekeys used in this scenario run
-      const keysToDelete = await this.getCache(this.cachePrefix);
+      const keysToDelete = await this.getCache(this.cachePrefix) || [];
+      // get the keys from Salesloft
+      const salesloftKeys = await this.getCache(`${this.cachePrefix.slice(0, -10)}Salesloft`) || [];
+      keysToDelete.push(...salesloftKeys);
       if (keysToDelete.length) {
         keysToDelete.forEach((key: string) => this.delAsync(key));
       }
-      this.setAsync(this.cachePrefix, 600, '[]');
+      await this.setAsync(this.cachePrefix, 600, '[]');
+      await this.setAsync(`${this.cachePrefix.slice(0, -10)}Salesloft`, 600, '[]');
     } catch (err) {
       console.log(err);
     }

--- a/test/client/caching-client-wrapper.ts
+++ b/test/client/caching-client-wrapper.ts
@@ -380,9 +380,11 @@ describe('CachingClientWrapper', () => {
     const expectedObjName = 'Test';
     const expectedObj = {a: 1};
     cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest.clearCache = sinon.spy();
     cachingClientWrapperUnderTest.updateObject(expectedObjName, expectedObj);
 
     setTimeout(() => {
+      expect(cachingClientWrapperUnderTest.clearCache).to.have.been.called;
       expect(clientWrapperStub.updateObject).to.have.been.calledWith(expectedObjName, expectedObj);
       done();
     });
@@ -392,9 +394,11 @@ describe('CachingClientWrapper', () => {
     const expectedObjName = 'Test';
     const expectedId = '123';
     cachingClientWrapperUnderTest = new CachingClientWrapper(clientWrapperStub, redisClientStub, idMap);
+    cachingClientWrapperUnderTest.clearCache = sinon.spy();
     cachingClientWrapperUnderTest.deleteObjectById(expectedObjName, expectedId);
 
     setTimeout(() => {
+      expect(cachingClientWrapperUnderTest.clearCache).to.have.been.called;
       expect(clientWrapperStub.deleteObjectById).to.have.been.calledWith(expectedObjName, expectedId);
       done();
     });


### PR DESCRIPTION
Set the clearCache() function to delete the Saleforce and Salesloft cache from the scenario.