### PR TITLE
Caching fix for salesforce instances with too many fields

### DIFF
--- a/src/client/caching-client-wrapper.ts
+++ b/src/client/caching-client-wrapper.ts
@@ -14,6 +14,10 @@ class CachingClientWrapper {
   // -------------------------------------------------------------------
 
   public async findContactByEmail(email: string, alwaysRetrieve: string[] = []) {
+    const mayGenerateBadRequest = await this.client.soqlSelectAllMayBeTooBig('Contact');
+    if (mayGenerateBadRequest) {
+      return await this.client.findContactByEmail(email, alwaysRetrieve, true);
+    }
     const cachekey = `Salesforce|Contact|${email}|${this.cachePrefix}`;
     const stored = await this.getCache(cachekey);
     if (stored) {
@@ -41,6 +45,10 @@ class CachingClientWrapper {
   // -------------------------------------------------------------------
 
   public async findAccountByIdentifier(idField: string, identifier: string, alwaysRetrieve: string[] = []): Promise<Record<string, any>[]> {
+    const mayGenerateBadRequest = await this.client.soqlSelectAllMayBeTooBig('Account');
+    if (mayGenerateBadRequest) {
+      return await this.client.findAccountByIdentifier(idField, identifier, alwaysRetrieve, true);
+    }
     const cachekey = `Salesforce|Account|${idField}${identifier}|${this.cachePrefix}`;
     const stored = await this.getCache(cachekey);
     if (stored) {
@@ -68,6 +76,10 @@ class CachingClientWrapper {
   // -------------------------------------------------------------------
 
   public async findOpportunityByIdentifier(idField: string, identifier: string, alwaysRetrieve: string[] = []): Promise<Record<string, any>[]> {
+    const mayGenerateBadRequest = await this.client.soqlSelectAllMayBeTooBig('Opportunity');
+    if (mayGenerateBadRequest) {
+      return await this.client.findOpportunityByIdentifier(idField, identifier, alwaysRetrieve, true);
+    }
     const cachekey = `Salesforce|Opportunity|${idField}${identifier}|${this.cachePrefix}`;
     const stored = await this.getCache(cachekey);
     if (stored) {
@@ -95,6 +107,10 @@ class CachingClientWrapper {
   // -------------------------------------------------------------------
 
   public async findLeadByEmail(email: string, alwaysRetrieve: string[] = []) {
+    const mayGenerateBadRequest = await this.client.soqlSelectAllMayBeTooBig('Lead');
+    if (mayGenerateBadRequest) {
+      return await this.client.findLeadByEmail(email, alwaysRetrieve, true);
+    }
     const cachekey = `Salesforce|Lead|${email}|${this.cachePrefix}`;
     const stored = await this.getCache(cachekey);
     if (stored) {
@@ -122,6 +138,10 @@ class CachingClientWrapper {
   // -------------------------------------------------------------------
 
   public async findCCIOById(id: string, alwaysRetrieveFields: string[] = []) {
+    const mayGenerateBadRequest = await this.client.soqlSelectAllMayBeTooBig('LeanData__CC_Inserted_Object__c');
+    if (mayGenerateBadRequest) {
+      return await this.client.findCCIOById(id, alwaysRetrieveFields, true);
+    }
     const cachekey = `Salesforce|CCIO|${id}|${this.cachePrefix}`;
     const stored = await this.getCache(cachekey);
     if (stored) {
@@ -139,6 +159,10 @@ class CachingClientWrapper {
   // -------------------------------------------------------------------
 
   public async findCampaignById(campaignId: string, alwaysRetrieve: string[] = []) {
+    const mayGenerateBadRequest = await this.client.soqlSelectAllMayBeTooBig('Campaign');
+    if (mayGenerateBadRequest) {
+      return await this.client.findCampaignById(campaignId, alwaysRetrieve, true);
+    }
     const cachekey = `Salesforce|Campaign|${campaignId}|${this.cachePrefix}`;
     const stored = await this.getCache(cachekey);
     if (stored) {
@@ -156,6 +180,10 @@ class CachingClientWrapper {
   // -------------------------------------------------------------------
 
   public async findCampaignMemberByEmailAndCampaignId(email: string, campaignId: string, alwaysRetrieve: string[] = []) {
+    const mayGenerateBadRequest = await this.client.soqlSelectAllMayBeTooBig('CampaignMember');
+    if (mayGenerateBadRequest) {
+      return await this.client.findCampaignMemberByEmailAndCampaignId(email, campaignId, alwaysRetrieve, true);
+    }
     const cachekey = `Salesforce|CampaignMember|${campaignId}|${this.cachePrefix}`;
     const stored = await this.getCache(cachekey);
     if (stored) {

--- a/src/client/mixins/account-aware.ts
+++ b/src/client/mixins/account-aware.ts
@@ -20,8 +20,8 @@ export class AccountAwareMixin extends ObjectAwareMixin {
    * @param {String[]} alwaysRetrieve - an optional list of fields that should
    *   always be retrieved when finding accounts.
    */
-  public async findAccountByIdentifier(idField: string, identifier: string, alwaysRetrieve: string[] = []): Promise<Record<string, any>[]> {
-    return this.findObjectsbyFields('Account', { [idField]: identifier }, alwaysRetrieve);
+  public async findAccountByIdentifier(idField: string, identifier: string, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>[]> {
+    return this.findObjectsbyFields('Account', { [idField]: identifier }, alwaysRetrieve, mayGenerateBadRequest);
   }
 
   /**

--- a/src/client/mixins/campaign-aware.ts
+++ b/src/client/mixins/campaign-aware.ts
@@ -9,7 +9,7 @@ export class CampaignAwareMixin extends ObjectAwareMixin {
    * @param {String[]} alwaysRetrieve - An optional list of fields that should
    *   always be retrieved when finding campaigns.
    */
-  public async findCampaignById(campaignId: string, alwaysRetrieve: string[] = []): Promise<Record<string, any>> {
-    return this.findObjectByFields('Campaign', { Id: campaignId }, alwaysRetrieve);
+  public async findCampaignById(campaignId: string, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>> {
+    return this.findObjectByFields('Campaign', { Id: campaignId }, alwaysRetrieve, mayGenerateBadRequest);
   }
 }

--- a/src/client/mixins/campaign-member-aware.ts
+++ b/src/client/mixins/campaign-member-aware.ts
@@ -9,7 +9,7 @@ export class CampaignMemberAwareMixin extends ObjectAwareMixin {
    * @param {String[]} alwaysRetrieve - An optional list of fields that should
    *   always be retrieved when finding campaign members.
    */
-  public async findCampaignMemberByEmailAndCampaignId(email: string, campaignId: string, alwaysRetrieve: string[] = []): Promise<Record<string, any>> {
-    return this.findObjectByFields('CampaignMember', { Email: email, CampaignId: campaignId }, alwaysRetrieve);
+  public async findCampaignMemberByEmailAndCampaignId(email: string, campaignId: string, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>> {
+    return this.findObjectByFields('CampaignMember', { Email: email, CampaignId: campaignId }, alwaysRetrieve, mayGenerateBadRequest);
   }
 }

--- a/src/client/mixins/ccio-aware.ts
+++ b/src/client/mixins/ccio-aware.ts
@@ -10,7 +10,7 @@ export class CCIOAwareMixin extends ObjectAwareMixin {
    * @param {String[]} alwaysRetrieveFields - An optional array of fields that
    *   should always be retrieved.
    */
-  public async findCCIOById(id: string, alwaysRetrieveFields: string[] = []): Promise<Record<string, any>> {
-    return this.findObjectByField('LeanData__CC_Inserted_Object__c', 'LeanData__Lead__c', id, alwaysRetrieveFields);
+  public async findCCIOById(id: string, alwaysRetrieveFields: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>> {
+    return this.findObjectByField('LeanData__CC_Inserted_Object__c', 'LeanData__Lead__c', id, alwaysRetrieveFields, mayGenerateBadRequest);
   }
 }

--- a/src/client/mixins/contact-aware.ts
+++ b/src/client/mixins/contact-aware.ts
@@ -39,7 +39,7 @@ export class ContactAwareMixin extends ObjectAwareMixin {
    * @param {String[]} alwaysRetrieve - An optional list of fields that should
    *   always be retrieved when finding this contact.
    */
-  public async findContactByEmail(email: string, alwaysRetrieve: string[] = []) {
-    return this.findObjectByField('Contact', 'Email', email, alwaysRetrieve);
+  public async findContactByEmail(email: string, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false) {
+    return this.findObjectByField('Contact', 'Email', email, alwaysRetrieve, mayGenerateBadRequest);
   }
 }

--- a/src/client/mixins/lead-aware.ts
+++ b/src/client/mixins/lead-aware.ts
@@ -19,8 +19,8 @@ export class LeadAwareMixin extends ObjectAwareMixin {
    * @param {String[]} alwaysRetrieveFields - An optional array of fields that
    *   should always be retrieved.
    */
-  public async findLeadByEmail(email: string, alwaysRetrieveFields: string[] = []): Promise<Record<string, any>> {
-    return this.findObjectByField('Lead', 'Email', email, alwaysRetrieveFields);
+  public async findLeadByEmail(email: string, alwaysRetrieveFields: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>> {
+    return this.findObjectByField('Lead', 'Email', email, alwaysRetrieveFields, mayGenerateBadRequest);
   }
 
   /**

--- a/src/client/mixins/object-aware.ts
+++ b/src/client/mixins/object-aware.ts
@@ -37,8 +37,8 @@ export class ObjectAwareMixin {
    * @param {String[]} alwaysRetrieve - An optional list of fields that should
    *   always be retrieved for the given object.
    */
-  public async findObjectById(objName: string, id: string, alwaysRetrieve: string[] = []): Promise<Record<string, any>> {
-    return this.findObjectByField(objName, 'Id', id, alwaysRetrieve);
+  public async findObjectById(objName: string, id: string, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>> {
+    return this.findObjectByField(objName, 'Id', id, alwaysRetrieve, mayGenerateBadRequest);
   }
 
   /**
@@ -50,8 +50,8 @@ export class ObjectAwareMixin {
    * @param alwaysRetrieve - An optional list of fields that should always be
    *   retrieved for the given object.
    */
-  public async findObjectByField(objName: string, field: string, value: string, alwaysRetrieve: string[] = []): Promise<Record<string, any>> {
-    return this.findObjectByFields(objName, { [field]: value }, alwaysRetrieve);
+  public async findObjectByField(objName: string, field: string, value: string, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>> {
+    return this.findObjectByFields(objName, { [field]: value }, alwaysRetrieve, mayGenerateBadRequest);
   }
 
   /**
@@ -63,8 +63,10 @@ export class ObjectAwareMixin {
    *   retrieved (only ever used if the underlying object has an unexpectedly
    *   large number of fields).
    */
-  public async findObjectByFields(objName: string, fieldMap: Record<string, any>, alwaysRetrieve: string[] = []): Promise<Record<string, any>> {
-    const mayGenerateBadRequest = await this.soqlSelectAllMayBeTooBig(objName);
+  public async findObjectByFields(objName: string, fieldMap: Record<string, any>, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>> {
+    if (!mayGenerateBadRequest) {
+      mayGenerateBadRequest = await this.soqlSelectAllMayBeTooBig(objName);
+    }
     let retrieveFields = null;
 
     // If the request generated may be too large, only pull standard fields, as
@@ -100,8 +102,10 @@ export class ObjectAwareMixin {
    *   retrieved when finding objects of this type (only ever used if the
    *   underlying object type has an unexpectedly large number of fields).
    */
-  public async findObjectsbyFields(objName: string, fieldMap: Record<string, any>, alwaysRetrieve: string[] = []): Promise<Record<string, any>[]> {
-    const mayGenerateBadRequest = await this.soqlSelectAllMayBeTooBig(objName);
+  public async findObjectsbyFields(objName: string, fieldMap: Record<string, any>, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>[]> {
+    if (!mayGenerateBadRequest) {
+      mayGenerateBadRequest = await this.soqlSelectAllMayBeTooBig(objName);
+    }
     let retrieveFields = null;
 
     // If the request generated may be too large, only pull standard fields, as
@@ -217,7 +221,7 @@ export class ObjectAwareMixin {
    *
    * @see https://salesforce.stackexchange.com/questions/195449/what-is-the-longest-uri-that-salesforce-will-accept-through-the-rest-api/195450
    */
-  protected async soqlSelectAllMayBeTooBig(objName: string): Promise<Boolean> {
+  public async soqlSelectAllMayBeTooBig(objName: string): Promise<Boolean> {
     const description = await this.describeObject(objName);
     const mockql = encodeURIComponent(`select ${description.fields.map(f => f.name).join(', ')} from ${objName}`);
     return mockql.length > 15000;

--- a/src/client/mixins/opportunity-aware.ts
+++ b/src/client/mixins/opportunity-aware.ts
@@ -22,8 +22,8 @@ export class OpportunityAwareMixin extends ObjectAwareMixin {
    * @param {String} alwaysRetrieve - an optional list of fields that should
    *   always be retrieved when finding opportunities.
    */
-  public async findOpportunityByIdentifier(idField: string, identifier: string, alwaysRetrieve: string[] = []): Promise<Record<string, any>[]> {
-    return this.findObjectsbyFields('Opportunity', { [idField]: identifier }, alwaysRetrieve);
+  public async findOpportunityByIdentifier(idField: string, identifier: string, alwaysRetrieve: string[] = [], mayGenerateBadRequest: Boolean = false): Promise<Record<string, any>[]> {
+    return this.findObjectsbyFields('Opportunity', { [idField]: identifier }, alwaysRetrieve, mayGenerateBadRequest);
   }
 
   /**

--- a/test/client/caching-client-wrapper.ts
+++ b/test/client/caching-client-wrapper.ts
@@ -38,6 +38,7 @@ describe('CachingClientWrapper', () => {
       createObject: sinon.spy(),
       findObjectByFields: sinon.spy(),
       findObjectsbyFields: sinon.spy(),
+      soqlSelectAllMayBeTooBig: sinon.spy(),
     };
 
     redisClientStub = {
@@ -60,6 +61,7 @@ describe('CachingClientWrapper', () => {
     cachingClientWrapperUnderTest.findContactByEmail(expectedEmail);
 
     setTimeout(() => {
+      expect(clientWrapperStub.soqlSelectAllMayBeTooBig).to.have.been.calledWith('Contact');
       expect(clientWrapperStub.findContactByEmail).to.have.been.calledWith(expectedEmail);
       done();
     });
@@ -102,6 +104,7 @@ describe('CachingClientWrapper', () => {
     cachingClientWrapperUnderTest.findAccountByIdentifier(expectedField, expectedId);
 
     setTimeout(() => {
+      expect(clientWrapperStub.soqlSelectAllMayBeTooBig).to.have.been.calledWith('Account');
       expect(clientWrapperStub.findAccountByIdentifier).to.have.been.calledWith(expectedField, expectedId);
       done();
     });
@@ -146,6 +149,7 @@ describe('CachingClientWrapper', () => {
     cachingClientWrapperUnderTest.findOpportunityByIdentifier(expectedField, expectedId);
 
     setTimeout(() => {
+      expect(clientWrapperStub.soqlSelectAllMayBeTooBig).to.have.been.calledWith('Opportunity');
       expect(clientWrapperStub.findOpportunityByIdentifier).to.have.been.calledWith(expectedField, expectedId);
       done();
     });
@@ -189,6 +193,7 @@ describe('CachingClientWrapper', () => {
     cachingClientWrapperUnderTest.findLeadByEmail(expectedEmail);
 
     setTimeout(() => {
+      expect(clientWrapperStub.soqlSelectAllMayBeTooBig).to.have.been.calledWith('Lead');
       expect(clientWrapperStub.findLeadByEmail).to.have.been.calledWith(expectedEmail);
       done();
     });
@@ -231,6 +236,7 @@ describe('CachingClientWrapper', () => {
     cachingClientWrapperUnderTest.findCCIOById(expectedId);
 
     setTimeout(() => {
+      expect(clientWrapperStub.soqlSelectAllMayBeTooBig).to.have.been.calledWith('LeanData__CC_Inserted_Object__c');
       expect(clientWrapperStub.findCCIOById).to.have.been.calledWith(expectedId);
       done();
     });
@@ -260,6 +266,7 @@ describe('CachingClientWrapper', () => {
     cachingClientWrapperUnderTest.findCampaignById(expectedId);
 
     setTimeout(() => {
+      expect(clientWrapperStub.soqlSelectAllMayBeTooBig).to.have.been.calledWith('Campaign');
       expect(clientWrapperStub.findCampaignById).to.have.been.calledWith(expectedId);
       done();
     });
@@ -290,6 +297,7 @@ describe('CachingClientWrapper', () => {
     cachingClientWrapperUnderTest.findCampaignMemberByEmailAndCampaignId(expectedEmail, expectedCampaignId);
 
     setTimeout(() => {
+      expect(clientWrapperStub.soqlSelectAllMayBeTooBig).to.have.been.calledWith('CampaignMember');
       expect(clientWrapperStub.findCampaignMemberByEmailAndCampaignId).to.have.been.calledWith(expectedEmail, expectedCampaignId);
       done();
     });


### PR DESCRIPTION
This change will bypass caching when we check a field in a salesforce instance with too many (800+) fields to successfully make a REST API request.