### PR TITLE
PII suppression in step messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,9 +165,9 @@
       }
     },
     "@run-crank/utilities": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.0.tgz",
-      "integrity": "sha512-gEDbF8hl99dFtg3kN7hEnM4E82RAnX3+8HATXbPWiVIr7zop5SDIL6mlk/QxpHecOlYgM4jebHJ+dqCTdotqVg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@run-crank/utilities/-/utilities-0.5.1.tgz",
+      "integrity": "sha512-U9YS6zsu7/PCtJl6/PZRcnS8Dh3r4CWLyAg01MhUp7e5rkW2OXZUdosO0RcRYfQHWjs6flz8R2ATTo7TD/jsrQ==",
       "requires": {
         "csv-string": "^4.0.1",
         "moment": "^2.24.0"
@@ -1278,9 +1278,9 @@
       "integrity": "sha512-WfYwyJepTbjS5jWAWpVskOJ8Z10231HaFw6qJhSjGrpfMPf3yuoRohlasYsP/6/3YgTQcvZpTvoUo37eaei9Fw=="
     },
     "csv-string": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.0.tgz",
-      "integrity": "sha512-67UM45fosQvvh+HUvC8iNgg2B4UHWJ5Qud7TWy1EcbIQ9levAFKWudMk2k8U3LgXZP/Drr6eBwBwbSWq2N8HZA=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+      "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ=="
     },
     "csv-stringify": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "@run-crank/utilities": "^0.5.0",
+    "@run-crank/utilities": "^0.5.1",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.3",
     "jsforce": "^1.9.3",

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -85,8 +85,8 @@ export abstract class BaseStep {
     return stepDefinition;
   }
 
-  assert(operator: string, actualValue: string, expectedValue: string, field: string): util.AssertionResult {
-    return util.assert(operator, actualValue, expectedValue, field);
+  assert(operator: string, actualValue: string, expectedValue: string, field: string, piiLevel: string = null): util.AssertionResult {
+    return util.assert(operator, actualValue, expectedValue, field, piiLevel);
   }
 
   protected pass(message: string, messageArgs: any[] = [], records: StepRecord[] = []): RunStepResponse {

--- a/src/steps/account/account-field-equals.ts
+++ b/src/steps/account/account-field-equals.ts
@@ -93,7 +93,7 @@ export class AccountFieldEquals extends BaseStep implements StepInterface {
         return this.fail('The %s field does not exist on Account %s', [field, identifier], [record, orderedRecord]);
       }
 
-      const result = this.assert(operator, account[0][field], expectedValue, field);
+      const result = this.assert(operator, account[0][field], expectedValue, field, stepData['__piiSuppressionLevel']);
 
       // If the value of the field matches expectations, pass.
       // If the value of the field does not match expectations, fail.

--- a/src/steps/bulk-object-field-equals.ts
+++ b/src/steps/bulk-object-field-equals.ts
@@ -94,7 +94,7 @@ export class BulkObjectFieldEquals extends BaseStep implements StepInterface {
           // If the given field does not exist on the object, add it to the failArray
           failArray.push({ Id: obj.Id, message: `The ${field} field does not exist on this ${objName} object` });
         } else {
-          const assertResult = this.assert(operator, obj[field], expectedValue, field);
+          const assertResult = this.assert(operator, obj[field], expectedValue, field, stepData['__piiSuppressionLevel']);
           if (assertResult.valid) {
             successArray.push({ Id: obj.Id, message: assertResult.message });
           } else {

--- a/src/steps/campaign-member/campaign-member-field-equals.ts
+++ b/src/steps/campaign-member/campaign-member-field-equals.ts
@@ -121,7 +121,7 @@ export class CampaignMemberFieldEquals extends BaseStep implements StepInterface
         return this.fail('The %s field does not exist on Campaign Member with email %s and campaign %s', [field, email, textToDisplay], [record, orderedRecord]);
       }
 
-      const result = this.assert(operator, campaignMember[field], expectedValue, field);
+      const result = this.assert(operator, campaignMember[field], expectedValue, field, stepData['__piiSuppressionLevel']);
 
       // If the value of the field matches expectations, pass.
       // If the value of the field does not match expectations, fail.

--- a/src/steps/ccio/ccio-field-equals.ts
+++ b/src/steps/ccio/ccio-field-equals.ts
@@ -83,7 +83,7 @@ export class CCIOFieldEquals extends BaseStep implements StepInterface {
         return this.fail('The %s field does not exist on CCIO %s', [field, id], [record, orderedRecord]);
       }
 
-      const result = this.assert(operator, ccio[field], expectedValue, field);
+      const result = this.assert(operator, ccio[field], expectedValue, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], [record, orderedRecord])
         : this.fail(result.message, [], [record, orderedRecord]);

--- a/src/steps/contact/contact-field-equals.ts
+++ b/src/steps/contact/contact-field-equals.ts
@@ -80,7 +80,7 @@ export class ContactFieldEqualsStep extends BaseStep implements StepInterface {
         return this.fail('The %s field does not exist on Contact %s', [field, email], [record, orderedRecord]);
       }
 
-      const result = this.assert(operator, contact[field], expectedValue, field);
+      const result = this.assert(operator, contact[field], expectedValue, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], [record, orderedRecord])
         : this.fail(result.message, [], [record, orderedRecord]);

--- a/src/steps/lead/lead-field-equals.ts
+++ b/src/steps/lead/lead-field-equals.ts
@@ -84,7 +84,7 @@ export class LeadFieldEquals extends BaseStep implements StepInterface {
         return this.fail('The %s field does not exist on Lead %s', [field, email], [record, orderedRecord]);
       }
 
-      const result = this.assert(operator, lead[field], expectedValue, field);
+      const result = this.assert(operator, lead[field], expectedValue, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], [record, orderedRecord])
         : this.fail(result.message, [], [record, orderedRecord]);

--- a/src/steps/object-field-equals.ts
+++ b/src/steps/object-field-equals.ts
@@ -87,7 +87,7 @@ export class ObjectFieldEquals extends BaseStep implements StepInterface {
         return this.fail('The %s field does not exist on %s Object %s', [field, objName, id], [record, orderedRecord]);
       }
 
-      const result = this.assert(operator, object[field], expectedValue, field);
+      const result = this.assert(operator, object[field], expectedValue, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], [record, orderedRecord])
         : this.fail(result.message, [], [record, orderedRecord]);

--- a/src/steps/opportunity/opportunity-field-equals.ts
+++ b/src/steps/opportunity/opportunity-field-equals.ts
@@ -93,7 +93,7 @@ export class OpportunityFieldEquals extends BaseStep implements StepInterface {
         return this.error('The %s field does not exist on Opportunity %s', [field, identifier], [record, orderedRecord]);
       }
 
-      const result = this.assert(operator, opportunity[0][field], expectedValue, field);
+      const result = this.assert(operator, opportunity[0][field], expectedValue, field, stepData['__piiSuppressionLevel']);
 
       // If the value of the field matches expectations, pass.
       // If the value of the field does not match expectations, fail.

--- a/src/steps/task/task-field-equals.ts
+++ b/src/steps/task/task-field-equals.ts
@@ -93,7 +93,7 @@ export class TaskFieldEquals extends BaseStep implements StepInterface {
 
       // Assert field
       tasks.forEach((task) => {
-        const assertResult = this.assert(operator, task[field], expectedValue, field);
+        const assertResult = this.assert(operator, task[field], expectedValue, field, stepData['__piiSuppressionLevel']);
         if (assertResult.valid) {
           validResults.push(task);
           result = assertResult;

--- a/src/steps/tenant-usage-entitlements/tenant-usage-entitlement-field-equals.ts
+++ b/src/steps/tenant-usage-entitlements/tenant-usage-entitlement-field-equals.ts
@@ -85,7 +85,7 @@ export class TenantUsageEntitlementsFieldEquals extends BaseStep implements Step
         actual = (((object['AmountUsed'] || 0) / object['CurrentAmountAllowed']) * 100).toFixed(2);
       }
 
-      const result = this.assert(operator, actual, expectedValue, field);
+      const result = this.assert(operator, actual, expectedValue, field, stepData['__piiSuppressionLevel']);
 
       return result.valid ? this.pass(result.message, [], [record, orderedRecord])
         : this.fail(result.message, [], [record, orderedRecord]);


### PR DESCRIPTION
- Update typescript cog utilities
- Some step messages will have PII removed if a "__piiSuppressionLevel" is passed in the stepData